### PR TITLE
Fix inline tag splitting and comment formatting

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,6 @@
 /**
- * @file insert Non-Breaking SPace for CKEditor
- * Copyright (C) 2014 Alfonso Martínez de Lizarrondo
+ * @file insert Non-Breaking Space for CKEditor
+ * Copyright (C) 2014 Alfonso MartÃ­nez de Lizarrondo
  * Create a command and enable the Ctrl+Space shortcut to insert a non-breaking space in CKEditor
  *
  */
@@ -12,7 +12,7 @@ CKEDITOR.plugins.add( 'nbsp',
 		// Insert &nbsp; if Ctrl+Space is pressed:
 		editor.addCommand( 'insertNbsp', {
 			exec: function( editor ) {
-				editor.insertHtml( '&nbsp;' );
+				editor.insertHtml( '&nbsp;', 'text' );
 			}
 		});
 		editor.setKeystroke( CKEDITOR.CTRL + 32 /* space */, 'insertNbsp' );


### PR DESCRIPTION
**Major:**
Fixes https://github.com/ckeditor/ckeditor-dev/issues/2805 by setting `text mode` for `insertHTML()` method according to [CKE docs](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-insertHtml) for inserting "htmlified" plain text.

**Minor:**
Fixes text encoding as mentioned in CKE plugin homepage [comment](https://ckeditor.com/cke4/addon/nbsp#comment-3013032268).